### PR TITLE
fix: various RPC API documentation fixes

### DIFF
--- a/docs/1.client/rpc.md
+++ b/docs/1.client/rpc.md
@@ -15,7 +15,7 @@ We've observed that using `127.0.0.1` when IPv4 is disabled tends to break and n
 
 Unless explicitly disabled within Cider, all API requests require a valid API token. You can generate this token, or turn off authentication, from the menu at **Settings -> Connectivity -> Manage External Application Access to Cider** within Cider.
 
-The generated token should be passed in the `apitoken` header of all requests. Do not prefix the token with `Bearer` or any other string; just pass the token by itself in the header.
+The generated token should be passed in the `apptoken` header of all requests. Do not prefix the token with `Bearer` or any other string; just pass the token by itself in the header.
 
 This token is not required if disabled within the settings menu.
 

--- a/docs/1.client/rpc.md
+++ b/docs/1.client/rpc.md
@@ -312,6 +312,7 @@ If no item is currently playing but there is one in the playback history, it wil
   "status": "ok"
 }</pre>
 </code>
+</details>
 
 #### **GET** `/queue`
 
@@ -593,6 +594,7 @@ Note that the index is 1-indexed (starts at 1, not 0). Also note that the queue 
   "returnQueue": false
 }</pre>
 </code>
+</details>
 
 <details>
 <summary><b>200</b>: OK</summary>
@@ -644,12 +646,15 @@ Accepts a `position` in seconds to seek to. Note that `/now-playing` returns a t
   "position": 30
 }</pre>
 </code>
+</details>
 
 <details>
-<summary><b>204</b>: No Content</summary>
-```json
-// No Response Body...
-```
+<summary><b>200</b>: OK</summary>
+<code>
+<pre>{
+  "status": "ok"
+}</pre>
+</code>
 </details>
 
 #### **GET** `/volume`

--- a/docs/1.client/rpc.md
+++ b/docs/1.client/rpc.md
@@ -28,8 +28,12 @@ The API endpoints documented below are all nested under `/api/v1/playback`.
 Responds with an empty body and status code `204: No Content`. This endpoint can be used to quickly check that the RPC server is still active.
 
 <details>
-<summary><b>204</b>: No Content</summary>
-<code>// No response body...</code>
+<summary><b>200</b>: OK</summary>
+<code>
+<pre>{
+  "status": "ok"
+}</pre>
+</code>
 </details>
 
 #### **GET** `/is-playing`

--- a/docs/1.client/rpc.md
+++ b/docs/1.client/rpc.md
@@ -205,6 +205,7 @@ Accepts a `type` of item to play and an `id` for the item. `type` should be one 
   "status": "ok"
 }</pre>
 </code>
+</details>
 
 #### **POST** `/play-next`
 


### PR DESCRIPTION
- The RPC endpoint at `/api/v1/playback/active` now returns a status of `200 OK` and a body of `{"status": "ok"}`, where previously it returned a `204 No Content`.
- Also, previous PR had a typo in authentication header: it should be `apptoken`, not `apitoken` (as was documented).

This PR is just a quick fix to update the docs to reflect these two fixes.